### PR TITLE
Fix cargo:rerun-if commands

### DIFF
--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -2,8 +2,8 @@ mod macos;
 mod windows;
 
 pub fn setup() {
-  println!("cargo:rerun-if-changed=TYPE_DEF_TMP_PATH");
-  println!("cargo:rerun-if-changed=DEBUG_GENERATED_CODE");
+  println!("cargo:rerun-if-env-changed=TYPE_DEF_TMP_PATH");
+  println!("cargo:rerun-if-env-changed=DEBUG_GENERATED_CODE");
   match std::env::var("CARGO_CFG_TARGET_OS").as_deref() {
     Ok("macos") => macos::setup(),
     Ok("windows") => windows::setup(),


### PR DESCRIPTION
The `rerun-if-changed` command expects a path, but as these are env vars (and the path `./TYPE_DEF_TMP_PATH` doesn't exist), this re-runs the build script every time. This PR fixes this and uses `rerun-if-env-changed` instead

https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-env-changedname